### PR TITLE
Prefs: setter側でクランプ追加（speed/fontSize/baselineY）

### DIFF
--- a/Danmaku/Preferences/DanmakuPrefs.swift
+++ b/Danmaku/Preferences/DanmakuPrefs.swift
@@ -13,6 +13,11 @@ struct DanmakuPrefs {
         static let baselineY = "danmaku.baselineY"
     }
 
+    // Allowed ranges (hard guards)
+    private static let speedRange: ClosedRange<CGFloat> = 20.0...150.0
+    private static let fontRange: ClosedRange<CGFloat> = 14.0...48.0
+    private static let baselineRange: ClosedRange<CGFloat> = 40.0...300.0
+
     static func registerDefaults() {
         UserDefaults.standard.register(defaults: [
             Keys.speed: 60.0,
@@ -27,7 +32,8 @@ struct DanmakuPrefs {
             return v == 0 ? 60 : CGFloat(v)
         }
         set {
-            UserDefaults.standard.set(Double(newValue), forKey: Keys.speed)
+            let clamped = min(max(newValue, speedRange.lowerBound), speedRange.upperBound)
+            UserDefaults.standard.set(Double(clamped), forKey: Keys.speed)
             NotificationCenter.default.post(name: .danmakuPrefsChanged, object: nil)
         }
     }
@@ -38,7 +44,8 @@ struct DanmakuPrefs {
             return v == 0 ? 28 : CGFloat(v)
         }
         set {
-            UserDefaults.standard.set(Double(newValue), forKey: Keys.fontSize)
+            let clamped = min(max(newValue, fontRange.lowerBound), fontRange.upperBound)
+            UserDefaults.standard.set(Double(clamped), forKey: Keys.fontSize)
             NotificationCenter.default.post(name: .danmakuPrefsChanged, object: nil)
         }
     }
@@ -49,7 +56,8 @@ struct DanmakuPrefs {
             return v == 0 ? 80 : CGFloat(v)
         }
         set {
-            UserDefaults.standard.set(Double(newValue), forKey: Keys.baselineY)
+            let clamped = min(max(newValue, baselineRange.lowerBound), baselineRange.upperBound)
+            UserDefaults.standard.set(Double(clamped), forKey: Keys.baselineY)
             NotificationCenter.default.post(name: .danmakuPrefsChanged, object: nil)
         }
     }


### PR DESCRIPTION
- UserDefaults保存前にハードガードを追加
- Ranges: speed 20–150, fontSize 14–48, baselineY 40–300
- setterで丸め込み後に通知（.danmakuPrefsChanged）を維持
- 目的: UI以外からの異常値でも動作安定、オーバーレイ即時反映
- 受け入れ: speed=999→150に保存、fontSize/max=48、baselineY/max=300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced valid ranges for Danmaku settings (speed, font size, vertical position) to prevent extreme or out-of-range values.
  * Automatically clamps preference inputs to safe values while preserving existing “0” behavior.
  * Improves stability and visual consistency of on-screen comments, reducing glitches and layout issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->